### PR TITLE
Add libsensors_monitor to launchfile

### DIFF
--- a/system_monitor.launch
+++ b/system_monitor.launch
@@ -6,4 +6,7 @@
     <param name="n_processes" value="$(arg n_processes)" />
   </node>
 
+  <!-- Monitor cpu temperature -->
+  <node name="libsensors_monitor" pkg="libsensors_monitor" type="libsensors_monitor"/>  
+
 </launch>


### PR DESCRIPTION
This PR adds tempearature monitoring using the `libsensors` package. This PR has been created in order to implement https://github.com/Auterion/auterion_distro_cv/pull/23

One downside would be this will requite additional dependencies on running this node (libsensors), which is only supported upto kinetic. As our distribution is using kinetic it won't be a problem now, but something that we should keep track on