### PR TITLE
Revert "Add libsensors_monitor to launchfile"

### DIFF
--- a/system_monitor.launch
+++ b/system_monitor.launch
@@ -6,7 +6,4 @@
     <param name="n_processes" value="$(arg n_processes)" />
   </node>
 
-  <!-- Monitor cpu temperature -->
-  <node name="libsensors_monitor" pkg="libsensors_monitor" type="libsensors_monitor"/>  
-
 </launch>


### PR DESCRIPTION
This reverts commit 03e24609f38867da803e62c10c922176818460d9, which launches libsensors_monitor to monitor the temperature of the CPU. As libsensors_monitor publishes its diagnostic messages through the `/diagnostics` package, we decided not to use this package to monitor temperature