### PR TITLE
Set mavros dependency version

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,3 +1,4 @@
 - git:
     local-name: mavros
     uri: https://github.com/mavlink/mavros.git
+    version: c373472c75310d1b76f40d2e4ea8b0b72f894e36


### PR DESCRIPTION
This sets the mavros version to the merge commit of the companion process status message is included.

This PR also shows that the travis CI is running.