### PR TITLE
Read memory info from system

### DIFF
--- a/include/system_monitor_ros/system_monitor.h
+++ b/include/system_monitor_ros/system_monitor.h
@@ -31,7 +31,8 @@ public:
     boost::array<uint8_t, 8> getCpuCores();
     boost::array<uint8_t, 10> getCpuCombined();
     int8_t getBoardTemperature();
-    int8_t getRamTotal();
+    uint32_t getRamUsage();
+    uint32_t getRamTotal();
 
 private:
    	std::vector<CpuData> prev_cpu_times_;

--- a/include/system_monitor_ros/system_monitor.h
+++ b/include/system_monitor_ros/system_monitor.h
@@ -31,7 +31,7 @@ public:
     boost::array<uint8_t, 8> getCpuCores();
     boost::array<uint8_t, 10> getCpuCombined();
     int8_t getBoardTemperature();
-
+    int8_t getRamTotal();
 
 private:
    	std::vector<CpuData> prev_cpu_times_;

--- a/src/system_monitor.cpp
+++ b/src/system_monitor.cpp
@@ -103,3 +103,20 @@ int8_t SystemMonitor::getBoardTemperature() {
   readBoardTemperature();
   return board_temp_;
 }
+
+int8_t SystemMonitor::getRamTotal() {
+    FILE *meminfo = fopen("/proc/meminfo", "r");
+    
+    char line[256];
+    int ram;
+    while(fgets(line, sizeof(line), meminfo))
+    {
+        if(sscanf(line, "MemTotal: %d kB", &ram) == 1)
+        {
+            fclose(meminfo);
+            return ram;
+        }
+    }
+    fclose(meminfo);
+    return 0;
+}

--- a/src/system_monitor.cpp
+++ b/src/system_monitor.cpp
@@ -104,7 +104,7 @@ int8_t SystemMonitor::getBoardTemperature() {
   return board_temp_;
 }
 
-int8_t SystemMonitor::getRamTotal() {
+uint32_t SystemMonitor::getRamUsage() {
     FILE *meminfo = fopen("/proc/meminfo", "r");
     
     char line[256];
@@ -114,7 +114,28 @@ int8_t SystemMonitor::getRamTotal() {
         if(sscanf(line, "MemTotal: %d kB", &ram) == 1)
         {
             fclose(meminfo);
-            return ram;
+            return uint32_t(ram / 1000);
+        }
+    }
+    fclose(meminfo);
+    return 0;
+}
+
+uint32_t SystemMonitor::getRamTotal() {
+    FILE *meminfo = fopen("/proc/meminfo", "r");
+    
+    char line[256];
+    int ram_total;
+    int ram_free;
+
+    while(fgets(line, sizeof(line), meminfo))
+    {
+        sscanf(line, "MemTotal: %d kB", &ram_total);
+
+        if(sscanf(line, "MemAvailable: %d kB", &ram_free) == 1)
+        {
+            fclose(meminfo);
+            return uint32_t((ram_total - ram_free) / 1000);
         }
     }
     fclose(meminfo);

--- a/src/system_monitor_node.cpp
+++ b/src/system_monitor_node.cpp
@@ -82,6 +82,7 @@ int main(int argc, char* argv[]) {
     status_msg.cpu_cores = system_monitor_.getCpuCores();
     status_msg.cpu_combined = system_monitor_.getCpuCombined();
     status_msg.temperature_board = system_monitor_.getBoardTemperature();
+    status_msg.ram_usage = system_monitor_.getRamTotal();
 
     // publish system data
     onboardstatus_pub_.publish(status_msg);

--- a/src/system_monitor_node.cpp
+++ b/src/system_monitor_node.cpp
@@ -82,7 +82,8 @@ int main(int argc, char* argv[]) {
     status_msg.cpu_cores = system_monitor_.getCpuCores();
     status_msg.cpu_combined = system_monitor_.getCpuCombined();
     status_msg.temperature_board = system_monitor_.getBoardTemperature();
-    status_msg.ram_usage = system_monitor_.getRamTotal();
+    status_msg.ram_usage = system_monitor_.getRamUsage();
+    status_msg.ram_total = system_monitor_.getRamTotal();
 
     // publish system data
     onboardstatus_pub_.publish(status_msg);


### PR DESCRIPTION
This PR enables reading memory info from `/proc/meminfo`

After this gets merged, I will like to do a clean up of the reading / assembling message process so that we don't have redundant reading of files