### PR TITLE
Update topic naming

### DIFF
--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -29,12 +29,12 @@ jobs:
             if [ \"$(git show-ref --tags)\" ]; then \\
               tag=$(git describe --always --tags $(git rev-list --tags --max-count=1) | sed -n 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/p'); \\
               if [[ -z \$(echo $tag | xargs) ]]; then \\
-                echo 0.2.0; \\
+                echo 0.3.0; \\
               else \\
                 echo $tag; \\
               fi; \\
             else \\
-              echo 0.2.0; \\
+              echo 0.3.0; \\
             fi"
           )
           ARCH=$(bash -c "if [ \"${{ matrix.arch }}\" = \"x86_64\" ]; then echo amd64; elif [ \"${{ matrix.arch }}\" = \"aarch64\" ]; then echo arm64; fi")

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>system_monitor_ros</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Monitoring CPU, Memory and Processes</description>
 
   <maintainer email="nuno.marques@dronesolutions.io">Nuno Marques</maintainer>

--- a/src/system_monitor_node.cpp
+++ b/src/system_monitor_node.cpp
@@ -40,7 +40,7 @@ class OnboardComputerStatusPublisher : public rclcpp::Node {
 
   {
     ocs_publisher_ =
-        this->create_publisher<px4_msgs::msg::OnboardComputerStatus>("OnboardComputerStatus_PubSubTopic", 1);
+        this->create_publisher<px4_msgs::msg::OnboardComputerStatus>("fmu/onboard_computer_status/in", 1);
     cpu_publisher_ = this->create_publisher<std_msgs::msg::String>("/cpu_usage", 1);
     memory_pub_ = this->create_publisher<std_msgs::msg::String>("/memory_usage", 1);
     processes_pub_ = this->create_publisher<std_msgs::msg::String>("/processes", 1);


### PR DESCRIPTION
Updates the onboard_computer_status publisher topic to `fmu/onboard_computer_status/in`. This change will follow a soon to be done modification in `px4_ros_com`.

Bumps also the version to 0.3.0, which will be used for the new minor release.