### PR TITLE
Fix CPU data fields fill-in

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,0 +1,20 @@
+name: Check format
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'ros2'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  check_format:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install clang-format-12
+      run: sudo apt update && sudo apt install -y clang-format-12
+    - name: check_format
+      run: ./tools/check_code_format.sh

--- a/include/system_monitor_ros/system_monitor.h
+++ b/include/system_monitor_ros/system_monitor.h
@@ -1,5 +1,5 @@
-#include <atomic>
 #include <array>
+#include <atomic>
 #include <mutex>
 #include <queue>
 #include <thread>

--- a/launch/monitor_parameters.yaml
+++ b/launch/monitor_parameters.yaml
@@ -1,4 +1,5 @@
 system_monitor_node:
     ros__parameters:
+        enable_internal_pubs: false
         n_processes: 8
         rate: 2.0 # Hz

--- a/src/system_monitor.cpp
+++ b/src/system_monitor.cpp
@@ -6,13 +6,13 @@
  *
  */
 
+#include <system_monitor_ros/system_monitor.h>
 #include <unistd.h>
+
 #include <fstream>
 #include <iostream>
 #include <numeric>
 #include <sstream>
-
-#include <system_monitor_ros/system_monitor.h>
 
 using namespace std::chrono_literals;
 
@@ -30,7 +30,7 @@ SystemMonitor::~SystemMonitor() {
 }
 
 void SystemMonitor::SetCPUCombinedHist() {
-  while(!hist_stop_.load()) {
+  while (!hist_stop_.load()) {
     std::vector<CpuData> cpu_times = GetCpuTimes();
 
     std::unique_lock<std::mutex> lock(hist_mtx_);

--- a/tools/check_code_format.sh
+++ b/tools/check_code_format.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fix style recursively in all the repository
-sh fix_style.sh ..
+$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/fix_style.sh ../
 
 # Print the diff with the remote branch (empty if no diff)
 git --no-pager diff -U0 --color

--- a/tools/fix_style.sh
+++ b/tools/fix_style.sh
@@ -13,9 +13,9 @@ fi
 for arg in "$@"
 do
     if [ -f $arg ]; then
-        clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
+        clang-format-12 -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
     elif [ -d $arg ]; then
-        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
+        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-12 -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
         find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs chmod 644
     fi
 done


### PR DESCRIPTION
- The `cpu_combined` field wasn't following the MAVLink message spec for the `[ONBOARD_COMPUTER_STATUS](https://mavlink.io/en/messages/common.html#ONBOARD_COMPUTER_STATUS)` message. There it can be read, for this field: _Combined CPU usage as the last 10 slices of 100 MS (a histogram). This allows to identify spikes in load that max out the system, but only for a short amount of time. A value of UINT8_MAX implies the field is unused._ This is useful when we publish the message a lower rates and still want to capture the latest ten computed CPU usage values in the last second.
- Both `cpu_combined` and `cpu_cores` arrays weren't being initialized to 255, which needs to happen specially to `cpu_cores` since not all the fields might be filled.
- Other publishers than the one for `onboard_computer_status` are using system commands that slow done the node publishing rate. So these were made optional through a parameter and set to false by default.